### PR TITLE
Make methods in times available at the top level of human_readable

### DIFF
--- a/src/human_readable/__init__.py
+++ b/src/human_readable/__init__.py
@@ -9,14 +9,22 @@ from human_readable.numbers import int_comma
 from human_readable.numbers import int_word
 from human_readable.numbers import ordinal
 from human_readable.numbers import scientific_notation
+from human_readable.times import date
 from human_readable.times import date_time
+from human_readable.times import day
 from human_readable.times import precise_delta
+from human_readable.times import time_delta
+from human_readable.times import time_of_day
+from human_readable.times import timing
+from human_readable.times import year
 
 
 __all__ = [
     "activate",
     "ap_number",
+    "date",
     "date_time",
+    "day",
     "deactivate",
     "file_size",
     "fractional",
@@ -26,4 +34,8 @@ __all__ = [
     "ordinal",
     "precise_delta",
     "scientific_notation",
+    "time_delta",
+    "time_of_day",
+    "timing",
+    "year",
 ]


### PR DESCRIPTION
This is a fix for #526. This makes methods in times available at the top level of human_readable. Until now, `date_time` and `precise_delta` were imported, but the following methods were not available -- contrary to the content of the documentation.

- time_delta
- time_of_day
- timing
- year
- day
- date

This PR makes these methods available at the top level of human_readable. It's just adding them to `__all__` in `human_readable/__init__.py`.

 # result

```python
>>> import human_readable
>>> human_readable.time_delta
<function time_delta at 0x1007bf420>
>>>
```

## Note

If my PR is not appropriate and you can do it directly, please do so without hesitation.
(Please choose the way that is easier for you)