### PR TITLE
New versioning and fix for License

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   labeler:

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -2,19 +2,18 @@ name: Release
 
 on:
   push:
-    tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+    branches:
+      - main
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repository and set tag env
+      - name: Check out the repository
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -35,15 +34,9 @@ jobs:
         run: |
           hatch build
 
-      - name: Publish package on PyPI
+      - name: Publish package on TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-
-      - name: Publish the release notes
-        uses: release-drafter/release-drafter@v5
-        with:
-          tag: ${{ env.RELEASE_VERSION }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Human Readable"
 authors = [
   { name = "staticdev", email = "staticdev-support@proton.me"}
 ]
-license = "MIT"
+license = {text = "MIT"}
 readme = "README.md"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "human-readable"
-version = "1.3.3"
+dynamic = ["version"]
 description = "Human Readable"
 authors = [
   { name = "staticdev", email = "staticdev-support@proton.me"}
@@ -16,6 +16,9 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = []
+
+[tool.hatch.version]
+source = "vcs"
 
 [project.urls]
 homepage = "https://github.com/staticdev/human-readable"
@@ -200,5 +203,5 @@ exclude = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
[ACTIVATE TAG PROTECTION FOR ALL TAGS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules)

With this PR, we are creating: 
 - actual releases with pushing a tag in `vN.N.N` format. -> version format: `1.3.3`
 - test releases with main commit pushes -> version format: `1.3.4.dev3+gc543f61`

Licensing issue is fixed.

Closes #618 