### PR TITLE
Fix/694 pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,66 +1,47 @@
 repos:
-  - repo: local
+  # Modifiers
+  - repo: https://github.com/psf/black
+    rev: 24.10.0
     hooks:
-      - id: bandit
-        name: bandit
-        entry: bandit
-        language: system
-        types: [python]
-        require_serial: true
-        args: ["-c", "bandit.yml"]
       - id: black
-        name: black
-        entry: black
-        language: system
-        types: [python]
-        require_serial: true
-      - id: check-added-large-files
-        name: Check for added large files
-        entry: check-added-large-files
-        language: system
-      - id: check-toml
-        name: Check Toml
-        entry: check-toml
-        language: system
-        types: [toml]
-      - id: check-yaml
-        name: Check Yaml
-        entry: check-yaml
-        language: system
-        types: [yaml]
-      - id: end-of-file-fixer
-        name: Fix End of Files
-        entry: end-of-file-fixer
-        language: system
-        types: [text]
-        stages: [commit, push, manual]
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        types: [python]
-        require_serial: true
-      - id: isort
-        name: isort
-        entry: isort
-        require_serial: true
-        language: system
-        types_or: [cython, pyi, python]
-        args: ["--filter-files"]
-      - id: pyupgrade
-        name: pyupgrade
-        description: Automatically upgrade syntax for newer versions.
-        entry: pyupgrade
-        language: system
-        types: [python]
-        args: [--py38-plus]
-      - id: trailing-whitespace
-        name: Trim Trailing Whitespace
-        entry: trailing-whitespace-fixer
-        language: system
-        types: [text]
-        stages: [commit, push, manual]
+
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.1.2
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.19.0
+    hooks:
+      - id: pyupgrade
+        args: [--py38-plus]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        args: ["--filter-files"]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Modifiers
+      - id: trailing-whitespace
+      # Static Checkers
+      - id: check-added-large-files
+      - id: check-toml
+      - id: check-yaml
+      - id: end-of-file-fixer
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.1
+    hooks:
+      - id: flake8
+
+  # Static Checkers
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.10
+    hooks:
+      - id: bandit
+        additional_dependencies: [".[toml]"]
+        args: ["-c", "bandit.yml"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
 """Sphinx configuration."""
+
 from datetime import datetime
 
 

--- a/src/human_readable/__init__.py
+++ b/src/human_readable/__init__.py
@@ -1,4 +1,5 @@
 """Human Readable."""
+
 from human_readable.files import file_size
 from human_readable.i18n import activate
 from human_readable.i18n import deactivate

--- a/src/human_readable/i18n.py
+++ b/src/human_readable/i18n.py
@@ -1,4 +1,5 @@
 """Activate, get and deactivate translations."""
+
 from __future__ import annotations
 
 import gettext as gettext_module

--- a/src/human_readable/lists.py
+++ b/src/human_readable/lists.py
@@ -1,4 +1,5 @@
 """Tests for lists humanization."""
+
 from __future__ import annotations
 
 

--- a/src/human_readable/numbers.py
+++ b/src/human_readable/numbers.py
@@ -1,4 +1,5 @@
 """Humanizing functions for numbers."""
+
 from __future__ import annotations
 
 import fractions

--- a/src/human_readable/times.py
+++ b/src/human_readable/times.py
@@ -1,4 +1,5 @@
 """Time humanizing functions."""
+
 from __future__ import annotations
 
 import datetime as dt

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for functional tests."""
+
 import pytest
 from pytest_mock import MockerFixture
 

--- a/tests/functional/en_ABBR/test_numbers.py
+++ b/tests/functional/en_ABBR/test_numbers.py
@@ -1,4 +1,5 @@
 """Tests for ru_RU numbers humanizing."""
+
 from pytest_mock import MockerFixture
 
 import human_readable

--- a/tests/functional/en_ABBR/test_times.py
+++ b/tests/functional/en_ABBR/test_times.py
@@ -1,4 +1,5 @@
 """Tests for time humanizing."""
+
 import datetime as dt
 
 import pytest

--- a/tests/functional/fr_FR/test_numbers.py
+++ b/tests/functional/fr_FR/test_numbers.py
@@ -1,4 +1,5 @@
 """Tests for fr_FR numbers humanizing."""
+
 from pytest_mock import MockerFixture
 
 import human_readable.numbers as numbers

--- a/tests/functional/pt_BR/test_numbers.py
+++ b/tests/functional/pt_BR/test_numbers.py
@@ -1,4 +1,5 @@
 """Tests for pt_BR numbers humanizing."""
+
 import pytest
 from pytest_mock import MockerFixture
 

--- a/tests/functional/pt_BR/test_times.py
+++ b/tests/functional/pt_BR/test_times.py
@@ -1,4 +1,5 @@
 """Tests for pt_BR time humanizing."""
+
 from __future__ import annotations
 
 import datetime as dt

--- a/tests/functional/ru_RU/test_numbers.py
+++ b/tests/functional/ru_RU/test_numbers.py
@@ -1,4 +1,5 @@
 """Tests for ru_RU numbers humanizing."""
+
 from pytest_mock import MockerFixture
 
 import human_readable.numbers as numbers

--- a/tests/functional/ru_RU/test_times.py
+++ b/tests/functional/ru_RU/test_times.py
@@ -1,4 +1,5 @@
 """Tests for time humanizing."""
+
 import datetime as dt
 
 from pytest_mock import MockerFixture

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -1,4 +1,5 @@
 """Tests for file size humanization."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/test_i18n.py
+++ b/tests/unit/test_i18n.py
@@ -1,4 +1,5 @@
 """Tests for i18n."""
+
 import pytest
 
 import human_readable.i18n as i18n

--- a/tests/unit/test_lists.py
+++ b/tests/unit/test_lists.py
@@ -1,4 +1,5 @@
 """Tests for listing humanization."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/test_numbers.py
+++ b/tests/unit/test_numbers.py
@@ -1,4 +1,5 @@
 """Tests for numbers humanizing."""
+
 from __future__ import annotations
 
 import pytest

--- a/tests/unit/test_times.py
+++ b/tests/unit/test_times.py
@@ -1,4 +1,5 @@
 """Tests for time humanizing."""
+
 from __future__ import annotations
 
 import datetime as dt


### PR DESCRIPTION
Fixes: https://github.com/staticdev/human-readable/issues/694

The first commit modifies `.pre-commit-config.yaml` to use non-local repos, feel free to modify this to however it pleases you. The second commit just runs `pre-commit run --all-files` on the repo; most of the changes seem to be due to `black` wanting to add an extra line.

Also, I did remove some things like `stages: [commit, push, manual]` since the repo versions define these already as needed; feel free to add them back in if you desire.

I'm mostly making this PR because I cannot run the existing `pre-commit` locally because of the the linked bug; hopefully this makes contributions easier.