### PR TITLE
fix: carry suffix when rounding pushes file_size mantissa to base

### DIFF
--- a/src/human_readable/files.py
+++ b/src/human_readable/files.py
@@ -61,5 +61,10 @@ def file_size(
     for i, suffix in enumerate(suffixes):
         unit = base ** (i + 2)
         if byte_size < unit:
-            return f"{base * byte_size / unit:{formatting}}{suffix}"
+            formatted = f"{base * byte_size / unit:{formatting}}"
+            # Rounding can push the mantissa to base (e.g. 999,999 bytes is
+            # 999.999 KB, which rounds to "1000.0 KB"). Step up one suffix.
+            if float(formatted) >= base and i + 1 < len(suffixes):
+                return f"{byte_size / unit:{formatting}}{suffixes[i + 1]}"
+            return f"{formatted}{suffix}"
     return f"{base * byte_size / unit:{formatting}}{suffix}"

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -15,6 +15,10 @@ from human_readable import files
         (2900000, "2.9 MB"),  # millions number
         (2000000000, "2.0 GB"),  # billions number
         (10**26 * 30, "3000.0 YB"),  # giant number
+        # Rollover: mantissa rounds up to base, must carry to the next suffix
+        (999999, "1.0 MB"),
+        (999999999, "1.0 GB"),
+        (999999999999, "1.0 TB"),
     ],
 )
 def test_file_size(params: int, expected: str) -> None:


### PR DESCRIPTION
## Problem

`file_size(999999)` returns `'1000.0 KB'` instead of `'1.0 MB'`.

The suffix is chosen from the raw byte count (before formatting), but the `formatting` pattern rounds the mantissa afterward. When rounding pushes the mantissa to `base` (e.g. 999,999 / 1000 = 999.999 → "1000.0"), the function keeps the smaller suffix.

Same with `999,999,999` → `'1000.0 MB'` (should be `'1.0 GB'`).

## Fix

After computing the formatted string, check whether `float(formatted) >= base`. If true and a larger suffix is available, step up one suffix. The formula `byte_size / unit` gives the value in the next unit because `unit = base**(i+2)` is also the conversion factor for suffix `i+1`.

## Tests

Added three regression cases (KB→MB, MB→GB, GB→TB boundaries) to `test_file_size`.